### PR TITLE
Amend BigQuery config's inappropriate camel case name

### DIFF
--- a/src/main/java/com/metriql/warehouse/bigquery/BigQueryDataSource.kt
+++ b/src/main/java/com/metriql/warehouse/bigquery/BigQueryDataSource.kt
@@ -68,8 +68,8 @@ class BigQueryDataSource(override val config: BigQueryWarehouse.BigQueryConfig) 
                 credentialProjectId = fromStream.projectId
                 bigQuery.setCredentials(fromStream)
             }
-            config.keyFile != null -> {
-                val fromStream = ServiceAccountCredentials.fromStream(FileInputStream(config.keyFile))
+            config.keyfile != null -> {
+                val fromStream = ServiceAccountCredentials.fromStream(FileInputStream(config.keyfile))
                 credentialProjectId = fromStream.projectId
                 bigQuery.setCredentials(fromStream)
             }

--- a/src/main/java/com/metriql/warehouse/bigquery/BigQueryWarehouse.kt
+++ b/src/main/java/com/metriql/warehouse/bigquery/BigQueryWarehouse.kt
@@ -33,6 +33,7 @@ object BigQueryWarehouse : Warehouse<BigQueryWarehouse.BigQueryConfig> {
         val location: String? = null,
         val priority: String? = null,
         val retries: Int? = null,
+        @JsonAlias("key_file")
         val keyfile: String? = null,
         val method: Method? = null,
         val refresh_token: String? = null,

--- a/src/main/java/com/metriql/warehouse/bigquery/BigQueryWarehouse.kt
+++ b/src/main/java/com/metriql/warehouse/bigquery/BigQueryWarehouse.kt
@@ -33,7 +33,7 @@ object BigQueryWarehouse : Warehouse<BigQueryWarehouse.BigQueryConfig> {
         val location: String? = null,
         val priority: String? = null,
         val retries: Int? = null,
-        val keyFile: String? = null,
+        val keyfile: String? = null,
         val method: Method? = null,
         val refresh_token: String? = null,
         val client_id: String? = null,


### PR DESCRIPTION
# Background

- When I tried to connect  BigQuery using Service Account and keyfile.json, `metriql serve` failed.
-  Because dbt's BigQuery profile use 'keyfile' keyward, not 'keyFile'.
   - [https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile](https://docs.getdbt.com/reference/warehouse-profiles/bigquery-profile)

## Failed Log
```
> ./target/metriql-0.4-SNAPSHOT-bundle/metriql-0.4-SNAPSHOT/bin/metriql serve --project-dir ../dbt-sample                                                                             
11月 21, 2021 8:34:08 午後 ru.yandex.clickhouse.ClickHouseDriver <clinit>                                                                                                                                          
情報: Driver registered                                                                                                                                                                                            
Exception in thread "main" /Users/sohei.morita/.config/gcloud/application_default_credentials.json not found connecting the BigQuery. 
```

# Results
- I confirmed that build and connection were successful

## Log
```
> ./target/metriql-0.4-SNAPSHOT-bundle/metriql-0.4-SNAPSHOT/bin/metriql serve --project-dir ../dbt-sample
11月 22, 2021 10:14:01 午後 ru.yandex.clickhouse.ClickHouseDriver <clinit>
情報: Driver registered
11月 22, 2021 10:14:03 午後 com.metriql.service.model.DiscoverService discoverDimensionFieldTypes
情報: Discovering 2 dimensions of model `model_dbt_sample_order`
11月 22, 2021 10:14:06 午後 io.netty.util.internal.logging.Slf4JLogger info
情報: [id: 0x00d35d43] REGISTERED
11月 22, 2021 10:14:06 午後 io.netty.util.internal.logging.Slf4JLogger info
情報: [id: 0x00d35d43] BIND(/127.0.0.1:5656)
11月 22, 2021 10:14:06 午後 io.netty.util.internal.logging.Slf4JLogger info
情報: [id: 0x00d35d43, L:/127.0.0.1:5656] ACTIVE
11月 22, 2021 10:14:08 午後 com.metriql.deployment.SingleTenantDeployment logStart
情報: Serving 1 datasets
```


