### PR TITLE
fix:swagger and jackson version conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <postgresql.version>42.2.8</postgresql.version>
         <java.version>11</java.version>
         <aws.library>1.10.66</aws.library>
+        <swagger.version>1.6.9</swagger.version>
 
         <!--Plugin versions-->
         <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
@@ -386,6 +387,19 @@
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
             <version>${redshift.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>${swagger.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-datatype-joda</artifactId>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
this version have some error

Exception in thread "main" java.lang.NoSuchMethodError: com.fasterxml.jackson.databind.introspect.AnnotatedMember.getType(Lcom/fasterxml/jackson/databind/type/TypeBindings;)Lcom/fasterxml/jackson/databind/JavaType;
	at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:398)
	at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:185)
	at io.swagger.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:100)
	at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:236)
