### PR TITLE
fix space issue

### DIFF
--- a/src/main/java/com/metriql/warehouse/JDBCDataSource.kt
+++ b/src/main/java/com/metriql/warehouse/JDBCDataSource.kt
@@ -247,7 +247,7 @@ abstract class JDBCDataSource(
                 targetBuilder.add(warehouse.bridge.quoteIdentifier(table))
                 targetBuilder.joinToString(".")
             }
-        } + "AS ${warehouse.bridge.quoteIdentifier(aliasName)}"
+        } + " AS ${warehouse.bridge.quoteIdentifier(aliasName)}"
     }
 
     override fun fillDefaultsToTarget(target: Dataset.Target): Dataset.Target {


### PR DESCRIPTION
Running metriql with snowflake_sample_data will lead into following error: Object `'SNOWFLAKE_SAMPLE_DATA.TPCH_SF1.ORDERSAS' does not exist or not authorized. ` This bugfix will fix the error by adding the missing space. 